### PR TITLE
Use HTTP PATCH method for proxy updates.

### DIFF
--- a/src/ToxiproxyNetCore.Tests/ClientTests.cs
+++ b/src/ToxiproxyNetCore.Tests/ClientTests.cs
@@ -218,5 +218,13 @@ namespace ToxiproxyNetCore.Tests
             //default pattern is <type>_<stream>
             Assert.Equal("testName", toxic.Name);
         }
+
+        [Fact]
+        public async Task GetServerVersion()
+        {
+            var version = await Fixture.Client.VersionAsync();
+            Assert.NotNull(version);
+            Assert.NotEmpty(version);
+        }
     }
 }

--- a/src/ToxiproxyNetCore/Client.cs
+++ b/src/ToxiproxyNetCore/Client.cs
@@ -100,7 +100,7 @@ namespace Toxiproxy.Net
             {
                 var url = $"/proxies/{proxy.Name}";
                 var postPayload = JsonConvert.SerializeObject(proxy);
-                var response = await httpClient.PostAsync(url, new StringContent(postPayload, Encoding.UTF8, "application/json"));
+                var response = await httpClient.PatchAsync(url, new StringContent(postPayload, Encoding.UTF8, "application/json"));
 
                 await CheckIsSuccessStatusCode(response);
 
@@ -242,12 +242,12 @@ namespace Toxiproxy.Net
             using (var client = _clientFactory.Create())
             {
                 var url = $"proxies/{proxy.Name}/toxics";
-				var objectSerialized = JsonConvert.SerializeObject( 
-						toxic, 
-						new JsonSerializerSettings {
-							NullValueHandling = NullValueHandling.Ignore
-						} 
-					);
+                var objectSerialized = JsonConvert.SerializeObject( 
+                        toxic, 
+                        new JsonSerializerSettings {
+                            NullValueHandling = NullValueHandling.Ignore
+                        } 
+                    );
 
                 var response = await client.PostAsync(url, new StringContent(objectSerialized, Encoding.UTF8, "application/json"));
 
@@ -328,7 +328,7 @@ namespace Toxiproxy.Net
             {
                 var url = $"/proxies/{proxyName}/toxics/{existingToxicName}";
                 var objectSerialized = JsonConvert.SerializeObject(toxic);
-                var response = await client.PostAsync(url, new StringContent(objectSerialized, Encoding.UTF8, "application/json"));
+                var response = await client.PatchAsync(url, new StringContent(objectSerialized, Encoding.UTF8, "application/json"));
 
                 await CheckIsSuccessStatusCode(response);
 

--- a/src/ToxiproxyNetCore/Client.cs
+++ b/src/ToxiproxyNetCore/Client.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Text;
-using Newtonsoft.Json;
-using System.Net;
-using Toxiproxy.Net.Toxics;
 using System.Threading.Tasks;
+using Toxiproxy.Net.Toxics;
 
 namespace Toxiproxy.Net
 {
@@ -16,10 +16,12 @@ namespace Toxiproxy.Net
     {
         private readonly IHttpClientFactory _clientFactory;
         private readonly JsonConverter[] _deserializeConverter = { new JsonToxicsConverter() };
+        private readonly Lazy<Task<string>> _serverVersion;
 
         public Client(IHttpClientFactory clientFactory)
         {
             _clientFactory = clientFactory;
+            _serverVersion = new Lazy<Task<string>>(GetServerVersionAsync);
         }
 
         public async Task<IDictionary<string, Proxy>> AllAsync()
@@ -100,7 +102,15 @@ namespace Toxiproxy.Net
             {
                 var url = $"/proxies/{proxy.Name}";
                 var postPayload = JsonConvert.SerializeObject(proxy);
-                var response = await httpClient.PatchAsync(url, new StringContent(postPayload, Encoding.UTF8, "application/json"));
+                HttpResponseMessage response;
+                if (await ServerSupportsHttpPatchForProxyUpdates())
+                {
+                    response = await httpClient.PatchAsync(url, new StringContent(postPayload, Encoding.UTF8, "application/json"));
+                }
+                else
+                {
+                    response = await httpClient.PostAsync(url, new StringContent(postPayload, Encoding.UTF8, "application/json"));
+                }
 
                 await CheckIsSuccessStatusCode(response);
 
@@ -323,12 +333,20 @@ namespace Toxiproxy.Net
             {
                 throw new ArgumentNullException(nameof(toxic));
             }
-
+            
             using (var client = _clientFactory.Create())
             {
                 var url = $"/proxies/{proxyName}/toxics/{existingToxicName}";
                 var objectSerialized = JsonConvert.SerializeObject(toxic);
-                var response = await client.PatchAsync(url, new StringContent(objectSerialized, Encoding.UTF8, "application/json"));
+                HttpResponseMessage response;
+                if (await ServerSupportsHttpPatchForProxyUpdates())
+                {
+                    response = await client.PatchAsync(url, new StringContent(objectSerialized, Encoding.UTF8, "application/json"));
+                }
+                else
+                {
+                    response = await client.PostAsync(url, new StringContent(objectSerialized, Encoding.UTF8, "application/json"));
+                }
 
                 await CheckIsSuccessStatusCode(response);
 
@@ -371,7 +389,45 @@ namespace Toxiproxy.Net
                     var error = JsonConvert.DeserializeObject<ToxiProxiErrorMessage>(errorContent);
                     throw new ToxiProxiException("An error occurred: " + error.title);
             }
-            
+        }
+
+        /// <summary>
+        /// Get the Toxiproxy server version.
+        /// </summary>
+        /// <returns>The Toxiproxy server version.</returns>
+        public Task<string> VersionAsync()
+        {
+            return _serverVersion.Value;
+        }
+
+        /// <summary>
+        /// Get the Toxiproxy server version calling the dedicated endpoint.
+        /// </summary>
+        /// <returns>The server version as <see cref="Version"/> object.</returns>
+        private async Task<string> GetServerVersionAsync()
+        {
+            using (var httpClient = _clientFactory.Create())
+            {
+                var response = await httpClient.GetAsync("/version");
+                await CheckIsSuccessStatusCode(response);
+                return await response.Content.ReadAsStringAsync();
+            }
+        }
+
+        /// <summary>
+        /// Starting from version 2.6.0, Toxiproxy server supports HTTP PATCH method for proxy updates, 
+        /// and started deprecating updates using HTTP POST.
+        /// This method helps checking the server version so to allow using the preferred update HTTP method 
+        /// according to the server version, so we can support both ways without breaking.
+        /// <see href="https://github.com/Shopify/toxiproxy/blob/main/CHANGELOG.md#260---2023-08-22">See Toxiproxy changelog.</see>
+        /// </summary>
+        /// <returns><see cref="true"/> if server version is 2.6.0 or above.</returns>
+        private async Task<bool> ServerSupportsHttpPatchForProxyUpdates()
+        {
+            Version supportsPatchMethodForUpdates = new Version("2.6.0");
+
+            var serverVersion = new Version(await _serverVersion.Value);
+            return !(serverVersion.CompareTo(supportsPatchMethodForUpdates) < 0);
         }
     }
 }

--- a/src/ToxiproxyNetCore/Client.cs
+++ b/src/ToxiproxyNetCore/Client.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -403,14 +404,23 @@ namespace Toxiproxy.Net
         /// <summary>
         /// Get the Toxiproxy server version calling the dedicated endpoint.
         /// </summary>
-        /// <returns>The server version as <see cref="Version"/> object.</returns>
+        /// <returns>The server version number.</returns>
         private async Task<string> GetServerVersionAsync()
         {
             using (var httpClient = _clientFactory.Create())
             {
                 var response = await httpClient.GetAsync("/version");
                 await CheckIsSuccessStatusCode(response);
-                return await response.Content.ReadAsStringAsync();
+                var content = await response.Content.ReadAsStringAsync();
+
+                try
+                {
+                    return ((string)JObject.Parse(content)["version"]).Trim();
+                }
+                catch (JsonReaderException)
+                {
+                    return content;
+                }
             }
         }
 

--- a/src/ToxiproxyNetCore/HttpClientExtensions.cs
+++ b/src/ToxiproxyNetCore/HttpClientExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Toxiproxy.Net
+{
+    internal static class HttpClientExtensions
+    {
+        private static readonly HttpMethod PatchHttpMethod = new HttpMethod("PATCH");
+
+        public static Task<HttpResponseMessage> PatchAsync(this HttpClient httpClient, string requestUri, HttpContent content, CancellationToken cancellationToken = default)
+        {
+            return httpClient.PatchAsync(CreateUri(requestUri), content, cancellationToken);
+        }
+
+        private static Task<HttpResponseMessage> PatchAsync(this HttpClient httpClient, Uri requestUri, HttpContent content, CancellationToken cancellationToken = default)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(PatchHttpMethod, requestUri)
+            {
+                Content = content
+            };
+            return httpClient.SendAsync(request, cancellationToken);
+        }
+
+        private static Uri CreateUri(string uri)
+        {
+            if (string.IsNullOrEmpty(uri))
+            {
+                return null;
+            }
+            return new Uri(uri, UriKind.RelativeOrAbsolute);
+        }
+    }
+}


### PR DESCRIPTION
Starting from version 2.6.0 of Toxiproxy, using HTTP `POST` method for proxy updates has been deprecated in favor of HTTP `PATCH` ([changelog](
)).
This PR supports this change.
Since using HTTP `PATCH` with Toxiproxy versions older than 2.6.0 results in a `"Method not allowed"` error, I added the support for reading the server version, and use the appropriate _update_ method accordingly.

**Note:**
`HttpClient` does not have the `PatchAsync` method in `netstandard2.0`; in this PR, I preferred to not upgrade the library version and add a dedicated extension method.
If we want the "native" `PatchAsync` method, we should upgrade the library to `netstandard2.1` (at least).