### PR TITLE
Add support for reset_peer toxic

### DIFF
--- a/src/ToxiproxyNetCore.Tests/ProxyTests.cs
+++ b/src/ToxiproxyNetCore.Tests/ProxyTests.cs
@@ -155,6 +155,37 @@ namespace ToxiproxyNetCore.Tests
         }
 
         [Fact]
+        public async Task CreateANewResetPeerToxicShouldWork()
+        {
+            var client = Fixture.Client;
+
+            var proxy = new Proxy
+            {
+                Name = "testingProxy",
+                Enabled = true,
+                Listen = "127.0.0.1:9090",
+                Upstream = "google.com"
+            };
+
+            var newProxy = await client.AddAsync(proxy);
+
+            var toxic = new ResetPeerToxic
+            {
+                Name = "ResetPeerToxicTest",
+            };
+            toxic.Attributes.Timeout = 5;
+            var newToxic = await newProxy.AddAsync(toxic);
+
+            // Need to retrieve the proxy and check the toxic's values
+            Assert.Equal(toxic.Name, newToxic.Name);
+            Assert.Equal(toxic.Attributes.Timeout, newToxic.Attributes.Timeout);
+
+            // Check against current toxics in the proxy
+            var currentToxics = await newProxy.GetAllToxicsAsync();
+            Assert.Contains(currentToxics, t => t.Name == toxic.Name && t.Type == "reset_peer");
+        }
+
+        [Fact]
         public async Task CreateANewBandwidthToxicShouldWork()
         {
             var client = Fixture.Client;

--- a/src/ToxiproxyNetCore.Tests/ToxiproxyNetCore.Tests.csproj
+++ b/src/ToxiproxyNetCore.Tests/ToxiproxyNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/ToxiproxyNetCore/JsonToxicsConverter.cs
+++ b/src/ToxiproxyNetCore/JsonToxicsConverter.cs
@@ -35,6 +35,8 @@ namespace Toxiproxy.Net
                     return jsonObject.ToObject<SlicerToxic>();
                 case ToxicTypenames.LimitDataToxic:
                     return jsonObject.ToObject<LimitDataToxic>();
+                case ToxicTypenames.ResetPeerToxic:
+                    return jsonObject.ToObject<ResetPeerToxic>();
                 default:
                     throw new InvalidOperationException("Unknown type: " + typeName);
             }

--- a/src/ToxiproxyNetCore/Toxics/ResetPeerToxic.cs
+++ b/src/ToxiproxyNetCore/Toxics/ResetPeerToxic.cs
@@ -1,0 +1,25 @@
+﻿namespace Toxiproxy.Net.Toxics
+{
+    public sealed class ResetPeerToxic : ToxicBase
+    {
+        /// <summary>
+        /// The attributes for the ResetPeer Toxic
+        /// </summary>
+        public class ToxicAttributes
+        {
+            public int Timeout { get; set; }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeoutToxic"/> class.
+        /// </summary>
+        public ResetPeerToxic()
+        {
+            Attributes = new ToxicAttributes();
+        }
+
+        public ToxicAttributes Attributes { get; set; }
+
+        public override string Type => ToxicTypenames.ResetPeerToxic;
+    }
+}

--- a/src/ToxiproxyNetCore/Toxics/ToxicTypenames.cs
+++ b/src/ToxiproxyNetCore/Toxics/ToxicTypenames.cs
@@ -8,5 +8,6 @@
         public const string SlowCloseToxic = "slow_close";
         public const string TimeoutToxic = "timeout";
         public const string LimitDataToxic = "limit_data";
+        public const string ResetPeerToxic = "reset_peer";
     }
 }


### PR DESCRIPTION
This PR adds the support for the `reset_peer` toxic.
Looking at the [docs](https://github.com/Shopify/toxiproxy?tab=readme-ov-file#reset_peer), this toxic is almost identical to the [timeout toxic](https://github.com/Shopify/toxiproxy?tab=readme-ov-file#timeout), so the implementation has been pretty straightforward.
Integration tests included.
I also updated the _ToxiproxyNetCore.Tests_ project to .NET 8.0.