### PR TITLE
Update NuGet packages to fix vulnerabilities

### DIFF
--- a/src/ToxiproxyNetCore.Tests/ToxiproxyNetCore.Tests.csproj
+++ b/src/ToxiproxyNetCore.Tests/ToxiproxyNetCore.Tests.csproj
@@ -16,6 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />

--- a/src/ToxiproxyNetCore/Toxics/ResetPeerToxic.cs
+++ b/src/ToxiproxyNetCore/Toxics/ResetPeerToxic.cs
@@ -11,7 +11,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TimeoutToxic"/> class.
+        /// Initializes a new instance of the <see cref="ResetPeerToxic"/> class.
         /// </summary>
         public ResetPeerToxic()
         {


### PR DESCRIPTION
Package versions of:
- `System.Net.Http`
- `System.Text.RegularExpressions`

referenced in the `ToxiproxyNetcore.Tests` project were reported as vulnerable.
In this PR I updated the packages so to reference non-vulnerable versions.